### PR TITLE
perf: eliminate heap churn and redundant driver calls in playback hot path

### DIFF
--- a/src/AudioManager.cpp
+++ b/src/AudioManager.cpp
@@ -19,6 +19,21 @@ void AudioManager::configurePWM() {
   // Configure PWM with Morse frequency as base (higher than static noise)
   ledcSetup(Audio::SPEAKER_CHANNEL, MORSE_FREQUENCY, 8);
   ledcAttachPin(Pins::SPEAKER, Audio::SPEAKER_CHANNEL);
+  speakerAttached = true;
+}
+
+void AudioManager::attachSpeaker() {
+  if (!speakerAttached) {
+    ledcAttachPin(Pins::SPEAKER, Audio::SPEAKER_CHANNEL);
+    speakerAttached = true;
+  }
+}
+
+void AudioManager::detachSpeaker() {
+  if (speakerAttached) {
+    ledcDetachPin(Pins::SPEAKER);
+    speakerAttached = false;
+  }
 }
 
 void AudioManager::setVolume(int adcValue) {
@@ -34,12 +49,12 @@ void AudioManager::setVolume(int adcValue) {
     if (currentVolume == 0) {
       // Completely silence the audio and detach the pin
       ledcWrite(Audio::SPEAKER_CHANNEL, 0);
-      ledcDetachPin(Pins::SPEAKER);
+      detachSpeaker();
     }
     // Only make sound if the volume is greater than zero
     else if (isPlayingMorse || isStaticPlaying) {
       // Reattach pin if needed
-      ledcAttachPin(Pins::SPEAKER, Audio::SPEAKER_CHANNEL);
+      attachSpeaker();
 
       // Update volume for morse tone
       if (isPlayingMorse) {
@@ -87,7 +102,7 @@ int AudioManager::calculateStaticVolume() {
     volumeVariation = random(-5, 6);
   } else {
     // During crackle, apply the crackle volume variation
-    int crackleIntensity = random(staticVolume / 2, int(staticVolume * 1.5));
+    int crackleIntensity = random(staticVolume / 2, (staticVolume * 3) / 2);
     return constrain(crackleIntensity, 0, 255);
   }
 
@@ -120,16 +135,21 @@ void AudioManager::handlePlayback() {
 void AudioManager::playMorseTone() {
   isPlayingMorse = true;
   // Ensure PWM is attached
-  ledcAttachPin(Pins::SPEAKER, Audio::SPEAKER_CHANNEL);
+  attachSpeaker();
   // Set exact 600Hz frequency for Morse code
   ledcWriteTone(Audio::SPEAKER_CHANNEL, MORSE_FREQUENCY);
   ledcWrite(Audio::SPEAKER_CHANNEL, currentVolume);
 }
 
 void AudioManager::stopMorseTone() {
+  // Already stopped and detached - nothing to do (this is called every
+  // update tick during morse gaps, so skip redundant LEDC driver calls)
+  if (!isPlayingMorse && !speakerAttached) {
+    return;
+  }
   isPlayingMorse = false;
   ledcWrite(Audio::SPEAKER_CHANNEL, 0);
-  ledcDetachPin(Pins::SPEAKER);
+  detachSpeaker();
 }
 
 void AudioManager::playStaticNoise(int signalStrength) {
@@ -138,7 +158,7 @@ void AudioManager::playStaticNoise(int signalStrength) {
   currentSignalStrength = signalStrength;
 
   // Ensure PWM is attached
-  ledcAttachPin(Pins::SPEAKER, Audio::SPEAKER_CHANNEL);
+  attachSpeaker();
 
   // Update the static noise pattern
   updateStaticPattern();
@@ -229,5 +249,5 @@ void AudioManager::stop() {
   isPlayingMorse = false;
   isStaticPlaying = false;
   ledcWrite(Audio::SPEAKER_CHANNEL, 0);
-  ledcDetachPin(Pins::SPEAKER);
+  detachSpeaker();
 }

--- a/src/AudioManager.h
+++ b/src/AudioManager.h
@@ -26,6 +26,11 @@ class AudioManager {
   void configurePWM();
   int calculateVolumeLevel(int adcValue);
 
+  // Idempotent speaker pin attach/detach to avoid redundant LEDC driver
+  // calls from the playback loop
+  void attachSpeaker();
+  void detachSpeaker();
+
   // Static noise generation helper methods
   void updateStaticPattern();
   int calculateStaticVolume();
@@ -52,6 +57,7 @@ class AudioManager {
   bool isPlayingMorse = false;
   bool isCrackling = false;
   bool isStaticPlaying = false;     // Track if static noise is currently playing
+  bool speakerAttached = false;     // Track if speaker pin is attached to LEDC
   int currentSignalStrength = 255;  // Start with full signal (no static)
   int staticBaseFrequency = MIN_STATIC_FREQ;
 

--- a/src/MorseCode.cpp
+++ b/src/MorseCode.cpp
@@ -50,6 +50,10 @@ const char DOT = '.';
 const char DASH = '-';
 const char SPACE = ' ';
 
+// Static pattern strings returned by getSymbol for special cases
+static const char SPACE_SYMBOL[] = " ";
+static const char EMPTY_SYMBOL[] = "";
+
 void MorseCode::begin() {
   // Initialize MORSE_LEDS as digital output
   pinMode(Pins::MORSE_LEDS, OUTPUT);
@@ -64,7 +68,7 @@ void MorseCode::startMessage(const String& message) {
 void MorseCode::startMessage(const char* message) {
   stop();
 
-  currentMessage = String(message);  // Still need String for compatibility, but minimize usage
+  currentMessage = message;
   messageIndex = 0;
   symbolIndex = 0;
   inTuneInDelay = true;
@@ -98,15 +102,15 @@ void MorseCode::update() {
   const auto& timings = config.getCurrentMorseTimings();
 
   // If we need to start a new character
-  if (symbolIndex == 0 || currentMorseChar.isEmpty()) {
+  if (symbolIndex == 0 || currentMorseLen == 0) {
     if (messageIndex >= currentMessage.length()) {
       stop();
       return;
     }
 
     // Get next character's morse code
-    currentMorseChar = getSymbol(currentMessage[messageIndex]);
-    if (currentMorseChar.isEmpty()) {
+    setCurrentMorseChar(getSymbol(currentMessage[messageIndex]));
+    if (currentMorseLen == 0) {
       messageIndex++;
       return;
     }
@@ -134,8 +138,8 @@ void MorseCode::handleTuneInDelay(unsigned long currentTime, ConfigManager& conf
     lastStateChange = currentTime;
     // Start with first symbol ON
     if (messageIndex < currentMessage.length() && currentMessage[messageIndex] != SPACE) {
-      currentMorseChar = getSymbol(currentMessage[messageIndex]);
-      if (!currentMorseChar.isEmpty()) {
+      setCurrentMorseChar(getSymbol(currentMessage[messageIndex]));
+      if (currentMorseLen != 0) {
         config.setMorseToneOn(true);
         audio.playMorseTone();
         updateMorseLEDs(true);
@@ -156,8 +160,8 @@ void MorseCode::handleWordSpace(unsigned long currentTime, const Audio::MorseTim
     lastStateChange = currentTime;
     // Start next character with symbol ON
     if (messageIndex < currentMessage.length()) {
-      currentMorseChar = getSymbol(currentMessage[messageIndex]);
-      if (!currentMorseChar.isEmpty()) {
+      setCurrentMorseChar(getSymbol(currentMessage[messageIndex]));
+      if (currentMorseLen != 0) {
         config.setMorseToneOn(true);
         audio.playMorseTone();
         updateMorseLEDs(true);
@@ -176,7 +180,7 @@ void MorseCode::processSymbol(unsigned long currentTime, const Audio::MorseTimin
 
   // Determine the appropriate gap duration
   unsigned long gapDuration;
-  if (symbolIndex == currentMorseChar.length() - 1) {
+  if (symbolIndex == currentMorseLen - 1) {
     // Last symbol in character - use letter gap
     gapDuration = timings.letterGap;
   } else {
@@ -195,14 +199,14 @@ void MorseCode::processSymbol(unsigned long currentTime, const Audio::MorseTimin
   } else {
     if (currentTime - lastStateChange >= gapDuration) {
       symbolIndex++;
-      if (symbolIndex >= currentMorseChar.length()) {
+      if (symbolIndex >= currentMorseLen) {
         // Move to next character
         messageIndex++;
         symbolIndex = 0;
         // Start next character with symbol ON if available
         if (messageIndex < currentMessage.length() && currentMessage[messageIndex] != SPACE) {
-          currentMorseChar = getSymbol(currentMessage[messageIndex]);
-          if (!currentMorseChar.isEmpty()) {
+          setCurrentMorseChar(getSymbol(currentMessage[messageIndex]));
+          if (currentMorseLen != 0) {
             config.setMorseToneOn(true);
             audio.playMorseTone();
             updateMorseLEDs(true);
@@ -230,25 +234,28 @@ void MorseCode::stop() {
 
   messageIndex = 0;
   symbolIndex = 0;
-  currentMorseChar.clear();
+  setCurrentMorseChar(EMPTY_SYMBOL);
   inTuneInDelay = false;
 }
 
 void MorseCode::updateMorseLEDs(bool on) { digitalWrite(Pins::MORSE_LEDS, on ? HIGH : LOW); }
 
-String MorseCode::getSymbol(char c) const {
-  if (c == SPACE) return String(SPACE);
+const char* MorseCode::getSymbol(char c) const {
+  if (c == SPACE) return SPACE_SYMBOL;
 
   c = toupper(c);
   if (c >= 'A' && c <= 'Z') {
     // Read pattern from PROGMEM
-    const char* pattern = (const char*)pgm_read_ptr(&MORSE_PATTERNS[c - 'A']);
-    return String(pattern);
+    return (const char*)pgm_read_ptr(&MORSE_PATTERNS[c - 'A']);
   }
   if (c >= '0' && c <= '9') {
     // Read pattern from PROGMEM
-    const char* pattern = (const char*)pgm_read_ptr(&MORSE_PATTERNS[26 + (c - '0')]);
-    return String(pattern);
+    return (const char*)pgm_read_ptr(&MORSE_PATTERNS[26 + (c - '0')]);
   }
-  return "";  // Return empty string for unsupported characters
+  return EMPTY_SYMBOL;  // Unsupported characters
+}
+
+void MorseCode::setCurrentMorseChar(const char* pattern) {
+  currentMorseChar = pattern;
+  currentMorseLen = strlen(pattern);
 }

--- a/src/MorseCode.h
+++ b/src/MorseCode.h
@@ -27,7 +27,8 @@ class MorseCode {
   MorseCode(const MorseCode&) = delete;
   MorseCode& operator=(const MorseCode&) = delete;
 
-  String getSymbol(char c) const;
+  const char* getSymbol(char c) const;
+  void setCurrentMorseChar(const char* pattern);
   void updateMorseLEDs(bool on);
 
   // Helper methods to break down the update function
@@ -41,7 +42,10 @@ class MorseCode {
   String currentMessage;
   size_t messageIndex = 0;  // Current character in message
   size_t symbolIndex = 0;   // Current symbol in character
-  String currentMorseChar;  // Current character's morse code
+  // Current character's morse code: pointer into the static pattern table
+  // (no heap allocation in the playback hot path)
+  const char* currentMorseChar = "";
+  size_t currentMorseLen = 0;
 
   // Timing state
   unsigned long lastStateChange = 0;

--- a/src/PotentiometerReader.h
+++ b/src/PotentiometerReader.h
@@ -45,7 +45,7 @@ class PotentiometerReader {
 
     // Increase threshold for larger changes to prevent oscillation
     if (abs(difference) > hysteresis_ * 2) {
-      adaptiveThreshold = hysteresis_ * 1.5;
+      adaptiveThreshold = (hysteresis_ * 3) / 2;
     }
 
     // Only update if change exceeds threshold

--- a/src/Station.h
+++ b/src/Station.h
@@ -13,7 +13,7 @@ class Station {
   const char* getName() const { return name; }
   int getFrequency() const { return frequency; }
   WaveBand getBand() const { return band; }
-  String getMessage() const { return message; }
+  const String& getMessage() const { return message; }
   bool isEnabled() const { return enabled; }
 
   // Setters

--- a/src/WiFiManager.cpp
+++ b/src/WiFiManager.cpp
@@ -1153,7 +1153,8 @@ void WiFiManager::handleSettings() {
 
 void WiFiManager::handleGetTuningValue() {
   int tuningValue = PowerManager::getInstance().readADCRaw(Pins::TUNING_POT);
-  String response = "{\"value\":" + String(tuningValue) + "}";
+  char response[32];
+  snprintf(response, sizeof(response), "{\"value\":%d}", tuningValue);
   server.send(200, "application/json", response);
   startTime = millis();  // Reset the timeout counter
   PowerManager::getInstance().resetActivityTimer("Web Interface - Tuning Value Request");
@@ -1452,7 +1453,7 @@ String WiFiManager::generateStationList() const {
     stationHtml += F("<input type='text' name='msg_");
     stationHtml += String(i);
     stationHtml += F("' value='");
-    stationHtml += String(station->getMessage());
+    stationHtml += station->getMessage();
     stationHtml += F("' placeholder='Enter your morse code message'>");
     stationHtml += F("</div>");
     stationHtml += F("<!-- Hidden frequency input to maintain save functionality -->");


### PR DESCRIPTION
The 10ms system update loop was doing avoidable work on every tick:

- MorseCode allocated heap Strings for each character's morse pattern
  (getSymbol returned String by value, currentMorseChar was a String).
  Now uses const char* pointers into the static pattern table with a
  cached length, so steady-state playback does zero heap allocations.
- AudioManager::stopMorseTone() is called on every update tick during
  morse gaps and re-issued LEDC detach calls each time. Speaker pin
  attach/detach is now tracked and idempotent, skipping redundant LEDC
  driver calls while preserving identical pin-level behavior.
- Station::getMessage() returned the message String by value, copying
  it on every station lock; now returns a const reference.
- Replaced float math with equivalent integer math in the
  potentiometer hysteresis and static-crackle volume calculations.
- /tuning JSON response now uses a stack buffer instead of String
  concatenation, and the station list page avoids an extra String copy.

No user-visible behavior changes: morse timing, audio output, LED
behavior, and the web UI are unchanged.